### PR TITLE
Fix incorrect unit label: pCO2_wet_equ 'atm' to 'µatm' (MYL-36)

### DIFF
--- a/src/oceanpack/app/models/data_processor.py
+++ b/src/oceanpack/app/models/data_processor.py
@@ -43,7 +43,7 @@ class DataProcessor:
         """Compute pCO2 at the equilibrator in wet air."""
         from oceanpack.utils.helpers import ppm2uatm
         self.ds['pCO2_wet_equ'] = ppm2uatm(self.ds['CO2'], self.ds['PressEqu'])
-        self.ds['pCO2_wet_equ'].attrs['unit'] = 'atm'
+        self.ds['pCO2_wet_equ'].attrs['unit'] = 'µatm'
         self.ds['pCO2_wet_equ'].attrs['long_name'] = 'pCO2 at equilibrator/membrane in wet air'
 
     def remove_non_operating_phases(self):

--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -1,0 +1,34 @@
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# Author: Markus Ritschel
+# eMail:  git@markusritschel.de
+# Date:   2026-05-20
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+#
+import numpy as np
+import xarray as xr
+
+from oceanpack.app.models.data_processor import DataProcessor
+
+
+def _make_processor_for_pCO2():
+    """Build a minimal DataProcessor with CO2 and PressEqu for pCO2 computation."""
+    times = np.array(["2020-01-01"], dtype="datetime64[ns]")
+    proc = DataProcessor()
+    proc.ds = xr.Dataset(
+        {
+            "CO2": ("time", np.atleast_1d(400.0)),
+            "PressEqu": ("time", np.atleast_1d(1.0)),
+        },
+        coords={"time": times},
+    )
+    proc.ds["PressEqu"].attrs["unit"] = "atm"
+    return proc
+
+
+def test_pCO2_wet_equ_unit_label():
+    """pCO2_wet_equ must carry unit 'µatm', not 'atm'."""
+    proc = _make_processor_for_pCO2()
+    proc.compute_pCO2_wet_equ()
+
+    unit = proc.ds["pCO2_wet_equ"].attrs.get("unit")
+    assert unit == "µatm", f"Expected unit 'µatm', got '{unit}'"


### PR DESCRIPTION
## Summary

- `pCO2_wet_equ` unit attribute changed from `'atm'` to `'µatm'` in `compute_pCO2_wet_equ()` — `ppm2uatm()` produces µatm (ppm × atm = µatm), not atm
- Added `test_data_processor.py` with `test_pCO2_wet_equ_unit_label` to guard the correct label going forward
- No downstream consumers of the literal `'atm'` string found

**Note:** `pCO2_wet_sst` (added in the MYL-28 branch) has the same fix applied in a separate commit on `agent/atlas/10ac119b`.

## Test plan
- [x] `test_pCO2_wet_equ_unit_label` passes
- [x] No existing tests broke